### PR TITLE
fix(context): add required properties to updatePayload if not provided

### DIFF
--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -90,6 +90,6 @@ export type Strategy = 'IMMEDIATE' | 'LAST' | 'IMMEDIATE_CLEAR';
 /**
  * Message format to be used.
  */
-export type Action = 'CUSTOM';
+export type Action = 'CUSTOM' | 'LEADERBOARD';
 
 

--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -39,6 +39,12 @@ export function convertToFBInstantUpdatePayload(payload: UpdatePayload): UpdateP
     if (payload.strategy === "IMMEDIATE_CLEAR") {
         payload.strategy = "IMMEDIATE";
     }
+    if (typeof payload.action === "undefined") {
+        payload.action = "CUSTOM";
+    }
+    if (typeof payload.template === "undefined") {
+        payload.template = "";
+    }
     return payload;
 }
 


### PR DESCRIPTION
* Action and template are required for Facebook only, so they are marked as optional. If they are not provided on Facebook then they will default to action=CUSTOM and template="".
* Added LEADERBOARD type for action