### PR TITLE
refactor(core): move window objects to global

### DIFF
--- a/src/classes/player.ts
+++ b/src/classes/player.ts
@@ -118,7 +118,7 @@ export class Player {
             case "facebook":
                 return config.platformSDK.player.getID();
             case "wortal":
-                return (window as any).wortalSessionId;
+                return window.wortalSessionId;
             case "crazygames":
                 return this._crazyGamesPlayer?.id || this.generateRandomID();
             case "gd":

--- a/src/classes/session.ts
+++ b/src/classes/session.ts
@@ -19,7 +19,7 @@ export class Session {
         debug("Initializing session...");
         this._current.country = this._setCountry();
         this._current.platform = this._setPlatform();
-        this._current.gameId = (window as any).wortalGameID;
+        this._current.gameId = window.wortalGameID;
         this._current.browser = navigator.userAgent;
         debug("Session initialized: ", this._current);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,11 @@
 import * as _Wortal from './api';
 import { exception } from "./utils/logger";
 
-// This was directly ported over from the deprecated wortal.js. We can probably find a better way to do this.
-// See: https://developers.google.com/ad-placement/docs/example#indexhtml_web
-//TODO: explore different implementations for this
-(window as any).adsbygoogle = (window as any).adsbygoogle || [];
-(window as any).adBreak = (window as any).adConfig = function (o: any) {
-    (window as any).adsbygoogle.push(o);
-};
+/** Wortal API */
+const Wortal = _Wortal;
+window.Wortal = Wortal;
 
-// This is set by the Wortal backend and is used to identify a Wortal player via session.
-//TODO: deprecate this when player persistence is implemented
-(window as any).wortalSessionId = "";
-
-// Check if the SDK should be automatically initialized or not. Manual initialization is useful for games with
-// large asset bundles that need to be downloaded before the game starts. This allows the game to control when
-// it is shown to the player rather than the SDK automatically initializing and showing the game while the
-// assets are still loading.
+// Check if the SDK should be automatically initialized or not.
 let isAutoInit: boolean = true;
 const scriptElement = document.currentScript;
 const manualInitFlag = scriptElement?.getAttribute("data-manual-init");
@@ -24,17 +13,9 @@ if (manualInitFlag === "true") {
     isAutoInit = false;
 }
 
-/** Wortal API */
-const Wortal = _Wortal;
-(window as any).Wortal = Wortal;
-
-Wortal._initializeInternal({ autoInitialize: isAutoInit }).then(() => {
-    // Check Wortal.isInitialized or listen for the wortal-sdk-initialized event instead of relying on this.
-    // This returns before the SDK is fully initialized due to some async calls and late initialization after
-    // the platform SDKs finish loading. Do not rely on this for anything mission-critical as it does not represent
-    // the SDK being fully initialized.
-}).catch((error: any) => {
-    exception("SDK failed to initialize.", error);
-});
+Wortal._initializeInternal({autoInitialize: isAutoInit})
+    .catch((error: any) => {
+        exception("SDK failed to initialize.", error);
+    });
 
 export default Wortal;

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,0 +1,60 @@
+declare global {
+    const __VERSION__: string;
+
+    const LinkGame: any;
+    const ViberPlay: any;
+    const FBInstant: any;
+    const gdsdk: any;
+    const GamePix: any;
+
+    interface Window {
+        /**
+         * Wortal SDK
+         */
+        Wortal: any;
+        /**
+         * ID of the game as set by wortal-data.js. This is used to identify the game on the Wortal backend.
+         */
+        wortalGameID: string;
+        /**
+         * This is set by the Wortal backend and is used to identify a Wortal player via session.
+         */
+        wortalSessionId: string;
+        /**
+         * Google Adsense SDK. Push ads to this array to display them.
+         * See: https://developers.google.com/ad-placement/docs/example#indexhtml_web
+         */
+        adsbygoogle: object[];
+        /**
+         * Calls for an ad break. This is used by the Google Adsense SDK.
+         */
+        adBreak: Function;
+        /**
+         * Ad configuration. This is used by the Google Adsense SDK.
+         */
+        adConfig: Function;
+        /**
+         * GD SDK requires an options object to be set in the window that holds their configuration and events.
+         * he onEvent property is where we can listen for their SDK events.
+         * We use this to map their events to our own callbacks.
+         */
+        GD_OPTIONS: object;
+        /**
+         * CrazyGames SDK
+         */
+        CrazyGames: CrazyGamesSDK;
+        /**
+         * Shares the game on the specified platform. This is only supported on Wortal and was ported over from the now
+         * deprecated wortal.js. It is not recommended to use this function, as it is called from the page
+         * displaying the game.
+         * @hidden
+         */
+        shareGame: (destination: string, message: string) => void;
+    }
+
+    interface CrazyGamesSDK {
+        SDK: any;
+    }
+}
+
+export {};

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -533,3 +533,17 @@ export const API_URL = {
     TOURNAMENT_SHARE_ASYNC: "https://sdk.html5gameportal.com/api/wortal/#tournamentshareasync",
     TOURNAMENT_JOIN_ASYNC: "https://sdk.html5gameportal.com/api/wortal/#tournamentjoinasync",
 }
+
+/**
+ * Source URLs for platform SDKs.
+ * @hidden
+ */
+export const SDK_SRC = {
+    GOOGLE: "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js",
+    LINK: "https://lg.rgames.jp/libs/link-game-sdk/1.3.0/bundle.js",
+    VIBER: "https://vbrpl.io/libs/viber-play-sdk/1.14.0/bundle.js",
+    FACEBOOK: "https://connect.facebook.net/en_US/fbinstant.7.1.js",
+    GD: "https://html5.api.gamedistribution.com/main.min.js",
+    CRAZY_GAMES: "https://sdk.crazygames.com/crazygames-sdk-v2.js",
+    GAME_PIX: "https://integration.gamepix.com/sdk/v3/gamepix.sdk.js",
+}


### PR DESCRIPTION
This PR is part of a larger task to clean up the codebase by typing everything and removing the use of any wherever possible. What's included here:

- Created `global.ts` to hold window objects and global declarations
- Added regions in large files
- Moved onPause functionality to `wortal-utils`
- Moved SDK src URLs to `config`
- Cleaned up `src/index`